### PR TITLE
Support Defined I/O for GCC Fortran >= 7.x.y

### DIFF
--- a/src/lib/stringifor_string_t.F90
+++ b/src/lib/stringifor_string_t.F90
@@ -11,7 +11,7 @@ save
 ! expose StingiFor overloaded builtins and operators
 ! public :: adjustl, adjustr, count, index, len, len_trim, repeat, scan, trim, verify
 public :: adjustl, adjustr, count, index, len_trim, repeat, scan, trim, verify
-#ifndef __GFORTRAN__
+#if !(__GNUC__ < 7)
 public :: assignment(=), operator(//), operator(.cat.), operator(==), &
           operator(/=), operator(<), operator(<=), operator(>=), operator(>)
 #endif
@@ -146,7 +146,7 @@ type :: string
                               string_gt_character, &
                               character_gt_string                   !< Greater than operator overloading.
     ! IO
-#ifndef __GFORTRAN__
+#if !(__GNUC__ < 7)
     generic :: read(formatted) => read_formatted       !< Formatted input.
     generic :: write(formatted) => write_formatted     !< Formatted output.
     generic :: read(unformatted) => read_unformatted   !< Unformatted input.
@@ -213,7 +213,7 @@ type :: string
     procedure, private, pass(lhs) :: string_gt_character !< Greater than to character logical operator.
     procedure, private, pass(rhs) :: character_gt_string !< Greater than to character (inverted) logical operator.
     ! IO
-#ifndef __GFORTRAN__
+#if !(__GNUC__ < 7)
     procedure, private, pass(dtv) :: read_formatted                !< Formatted input.
     procedure, private, pass(dtv) :: read_delimited                !< Read a delimited input.
     procedure, private, pass(dtv) :: read_undelimited              !< Read an undelimited input.
@@ -240,7 +240,7 @@ interface string
   module procedure string_
 endinterface string
 
-#ifndef __GFORTRAN__
+#if !(__GNUC__ < 7)
 ! operators overloading interfaces
 interface operator(//)
   !< Builtin // overloading.
@@ -3874,7 +3874,7 @@ contains
    endfunction character_gt_string
 
    ! IO
-#ifndef __GFORTRAN__
+#if !(__GNUC__ < 7)
    subroutine read_formatted(dtv, unit, iotype, v_list, iostat, iomsg)
    !< Formatted input.
    !<

--- a/src/lib/stringifor_string_t.F90
+++ b/src/lib/stringifor_string_t.F90
@@ -240,7 +240,7 @@ interface string
   module procedure string_
 endinterface string
 
-#if !(__GNUC__ < 7)
+#if (__GNUC__ < 7)
 ! operators overloading interfaces
 interface operator(//)
   !< Builtin // overloading.


### PR DESCRIPTION
Solution proposed by:
https://github.com/szaghi/StringiFor/issues/20#issuecomment-447919797